### PR TITLE
pagination for students & teachers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3018,11 +3018,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3035,15 +3037,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3146,7 +3151,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3156,6 +3162,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3168,17 +3175,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3195,6 +3205,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3267,7 +3278,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3277,6 +3289,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3382,6 +3395,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/controllers/student.js
+++ b/src/controllers/student.js
@@ -10,7 +10,14 @@ const {
 const { deleteImage } = require('../utils/upload');
 
 async function getAllStudents(req, res) {
-  const total = await studentService.countAll();
+  const { q } = req.query;
+  let total;
+  if (q) {
+    total = await studentService.countAllWithSearch(q);
+  } else {
+    total = await studentService.countAll();
+  }
+
   const { pagination, sort, search } = convertQuery(req.query, total);
 
   const students = await studentService.getAll(pagination, sort, search);

--- a/src/controllers/teacher.js
+++ b/src/controllers/teacher.js
@@ -9,7 +9,14 @@ const {
 const { deleteImage } = require('../utils/upload');
 
 async function getAllTeachers(req, res) {
-  const total = await teacherService.countAll();
+  const { q } = req.query;
+  let total;
+  if (q) {
+    total = await teacherService.countAllWithSearch(q);
+  } else {
+    total = await teacherService.countAll();
+  }
+
   const { pagination, sort, search } = convertQuery(req.query, total);
 
   const teachers = await teacherService.getAll(pagination, sort, search);

--- a/src/models/personSchema.js
+++ b/src/models/personSchema.js
@@ -93,7 +93,7 @@ personSchema.statics.searchQueryCount = async function(key) {
     {
       $match: { fullName: new RegExp(key, 'i') }
     },
-    { $group: { _id: null, count: { $sum: 1 } } }
+    { $count: "count"}
   ];
 
   return this.aggregate(aggregate);

--- a/src/models/personSchema.js
+++ b/src/models/personSchema.js
@@ -81,5 +81,23 @@ personSchema.statics.searchQuery = async function(pagination, sort, key) {
   return this.aggregate(aggregate);
 };
 
+personSchema.statics.searchQueryCount = async function(key) {
+  const aggregate = [
+    {
+      $addFields: {
+        fullName: {
+          $concat: ['$firstName', ' ', '$lastName']
+        }
+      }
+    },
+    {
+      $match: { fullName: new RegExp(key, 'i') }
+    },
+    { $group: { _id: null, count: { $sum: 1 } } }
+  ];
+
+  return this.aggregate(aggregate);
+};
+
 // return a copy
 module.exports = (() => personSchema.clone())();

--- a/src/services/person.js
+++ b/src/services/person.js
@@ -39,9 +39,14 @@ class PersonService extends Service {
   }
 
   async countAllWithSearch(search) {
+    let count;
     const query = await this.Model.searchQueryCount(search);
-    const {count} = query[0];
-    return count;
+    if (!query[0]) {
+      count = 0;
+      return count;
+    }
+    count = query[0].count;
+    return count;;
   }
 }
 

--- a/src/services/person.js
+++ b/src/services/person.js
@@ -46,7 +46,7 @@ class PersonService extends Service {
       return count;
     }
     count = query[0].count;
-    return count;;
+    return count;
   }
 }
 

--- a/src/services/person.js
+++ b/src/services/person.js
@@ -37,6 +37,12 @@ class PersonService extends Service {
       }
     );
   }
+
+  async countAllWithSearch(search) {
+    const query = await this.Model.searchQueryCount(search);
+    const {count} = query[0];
+    return count;
+  }
 }
 
 module.exports = PersonService;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -5,6 +5,9 @@ const path = require('path');
 const fs = require('fs');
 
 const env = process.env.NODE_ENV;
+if (!process.env.PWD) {
+  process.env.PWD = process.cwd();
+}
 const logDirectory = path.join(process.env.PWD, 'logs');
 const errorDirectory = path.join(logDirectory, 'errors');
 


### PR DESCRIPTION
Dear Bear,

I tired to fix the pagination of collection students & teachers according to your reminder.

I think I cannot bypass the aggregate() function in personSchema, as we need to add a "fullName" fields for collection students & teachers. Therefore, I use "{ $group: { _id: null, count: { $sum: 1 } } }" in aggregate pipeline to get an array, which contains the number of eligible documents rather than the detailed documents.

Do you think it's a proper way to fix? Thanks.